### PR TITLE
feat: bump example deps

### DIFF
--- a/axum/hello-world/Cargo.toml
+++ b/axum/hello-world/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [lib]
 
 [dependencies]
-axum = "0.5"
+axum = "0.6.0"
 shuttle-service = { version = "0.7.2", features = ["web-axum"] }
-sync_wrapper = "0.1"
+sync_wrapper = "0.1.1"

--- a/axum/websocket/Cargo.toml
+++ b/axum/websocket/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 [lib]
 
 [dependencies]
-axum = { version = "0.5", features = ["ws"] }
-chrono = { version = "0.4", features = ["serde"] }
-futures = "0.3"
-hyper = { version = "0.14", features = ["client", "http2"] }
-hyper-tls = "0.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+axum = { version = "0.6.0", features = ["ws"] }
+chrono = { version = "0.4.23", features = ["serde"] }
+futures = "0.3.25"
+hyper = { version = "0.14.23", features = ["client", "http2"] }
+hyper-tls = "0.5.0"
+serde = { version = "1.0.148", features = ["derive"] }
+serde_json = "1.0.89"
 shuttle-service = { version = "0.7.2", features = ["web-axum"] }
-sync_wrapper = "0.1"
-tokio = { version = "1", features = ["full"] }
+sync_wrapper = "0.1.1"
+tokio = { version = "1.22.0", features = ["full"] }

--- a/poem/hello-world/Cargo.toml
+++ b/poem/hello-world/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [lib]
 
 [dependencies]
-poem = "1.3.35"
+poem = "1.3.49"
 shuttle-service = { version = "0.7.2", features = ["web-poem"] }

--- a/poem/mongodb/Cargo.toml
+++ b/poem/mongodb/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mongodb = "2.3.0"
-poem = "1.3.35"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+mongodb = "2.3.1"
+poem = "1.3.49"
+serde = { version = "1.0.148", features = ["derive"] }
+serde_json = "1.0.89"
 shuttle-service = { version = "0.7.2", features = ["web-poem"] }
 shuttle-shared-db = { version = "0.7.2", features = ["mongodb"] }

--- a/poem/postgres/Cargo.toml
+++ b/poem/postgres/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [lib]
 
 [dependencies]
-poem = "1.3.35"
-serde = "1.0"
+poem = "1.3.49"
+serde = "1.0.148"
 shuttle-service = { version = "0.7.2", features = ["web-poem"] }
 shuttle-shared-db = { version = "0.7.2", features = ["postgres"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }

--- a/rocket/authentication/Cargo.toml
+++ b/rocket/authentication/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 [lib]
 
 [dependencies]
-chrono = "0.4"
-jsonwebtoken = { version = "8", default-features = false }
-lazy_static = "1.4"
+chrono = "0.4.23"
+jsonwebtoken = { version = "8.1.1", default-features = false }
+lazy_static = "1.4.0"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { version = "0.7.2", features = ["web-rocket"] }

--- a/rocket/persist/Cargo.toml
+++ b/rocket/persist/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [lib]
 
 [dependencies]
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
-serde = { version = "1.0", features = ["derive"] }
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
+serde = { version = "1.0.148", features = ["derive"] }
 shuttle-persist = "0.7.2"
 shuttle-service = { version = "0.7.2", features = ["web-rocket"] }

--- a/rocket/postgres/Cargo.toml
+++ b/rocket/postgres/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [lib]
 
 [dependencies]
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
-serde = "1.0"
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
+serde = "1.0.148"
 shuttle-service = { version = "0.7.2", features = ["web-rocket"] }
 shuttle-shared-db = { version = "0.7.2", features = ["postgres"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }

--- a/rocket/secrets/Cargo.toml
+++ b/rocket/secrets/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [lib]
 
 [dependencies]
-anyhow = "1.0.62"
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
+anyhow = "1.0.66"
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 shuttle-secrets = "0.7.2"
 shuttle-service = { version = "0.7.2", features = ["web-rocket"] }

--- a/rocket/url-shortener/Cargo.toml
+++ b/rocket/url-shortener/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 [lib]
 
 [dependencies]
-nanoid = "0.4"
+nanoid = "0.4.0"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
-serde = "1.0"
+serde = "1.0.148"
 shuttle-service = { version = "0.7.2", features = ["web-rocket"] }
 shuttle-shared-db = { version = "0.7.2", features = ["postgres"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
-url = "2.2"
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
+url = "2.3.1"

--- a/salvo/hello-world/Cargo.toml
+++ b/salvo/hello-world/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [lib]
 
 [dependencies]
-salvo = "0.34.3"
+salvo = "0.37.5"
 shuttle-service = { version = "0.7.2", features = ["web-salvo"] }

--- a/serenity/hello-world/Cargo.toml
+++ b/serenity/hello-world/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [lib]
 
 [dependencies]
-anyhow = "1.0.62"
+anyhow = "1.0.66"
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 shuttle-secrets = "0.7.2"
 shuttle-service = { version = "0.7.2", features = ["bot-serenity"] }
-tracing = "0.1.35"
+tracing = "0.1.37"

--- a/serenity/postgres/Cargo.toml
+++ b/serenity/postgres/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 [lib]
 
 [dependencies]
-anyhow = "1.0.62"
-serde = "1.0"
+anyhow = "1.0.66"
+serde = "1.0.148"
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 shuttle-secrets = "0.7.2"
 shuttle-service = { version = "0.7.2", features = ["bot-serenity"] }
 shuttle-shared-db = { version = "0.7.2", features = ["postgres"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
-tracing = "0.1.35"
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
+tracing = "0.1.37"

--- a/thruster/postgres/Cargo.toml
+++ b/thruster/postgres/Cargo.toml
@@ -8,10 +8,10 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hyper = "0.14.20"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
+hyper = "0.14.23"
+serde = { version = "1.0.148", features = ["derive"] }
+serde_json = "1.0.89"
 shuttle-aws-rds = { version = "0.7.2", features = ["postgres"] }
 shuttle-service = { version = "0.7.2", features = ["web-thruster"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 thruster = { version = "1.3.0", features = ["hyper_server"] }

--- a/tide/postgres/Cargo.toml
+++ b/tide/postgres/Cargo.toml
@@ -8,8 +8,8 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.148", features = ["derive"] }
 shuttle-aws-rds = { version = "0.7.2", features = ["postgres"] }
 shuttle-service = { version = "0.7.2", features = ["web-tide"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tide = "0.16.0"

--- a/tower/hello-world/Cargo.toml
+++ b/tower/hello-world/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [lib]
 
 [dependencies]
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14.23", features = ["full"] }
 shuttle-service = { version = "0.7.2", features = ["web-tower"] }
-tower = { version = "0.4", features = ["full"] }
+tower = { version = "0.4.13", features = ["full"] }

--- a/warp/hello-world/Cargo.toml
+++ b/warp/hello-world/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 shuttle-service = { version = "0.7.2", features = ["web-warp"] }
-warp = "0.3.2"
+warp = "0.3.3"


### PR DESCRIPTION
This PR bumps all dependencies in the examples. A lot of these will break unless they are used with the updated `shuttle-service` deps in https://github.com/shuttle-hq/shuttle/pull/495. Meaning this branch should not be merged until that is released.

Note: When merging this, make sure to set the gitmodule branch in shuttle `main` to examples `main`. It is currently set to this branch until this is merged.