### PR TITLE
feat: add actix postgres example

### DIFF
--- a/actix-web/README.md
+++ b/actix-web/README.md
@@ -1,0 +1,5 @@
+# Actix Web with shuttle
+
+Normally one would configure an application with [Actix Web](https://docs.rs/actix-web/latest/actix_web/index.html) using the [App](https://docs.rs/actix-web/latest/actix_web/struct.App.html) struct. However, shuttle needs to move the users configuration across threads to start the server on our backend, and the `App` struct is `!Send` and `!Sync`.
+
+That means that for shuttle to support Actix Web, we need to use the [ServiceConfig](https://docs.rs/actix-web/latest/actix_web/web/struct.ServiceConfig.html) struct. You should be able to configure your application like you normally would, but some steps may be a bit different. If you do you find something that you would expect to be possible not working, please reach out and let us know.

--- a/actix-web/hello-world/Cargo.toml
+++ b/actix-web/hello-world/Cargo.toml
@@ -4,7 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-actix-service = "2.0.2"
 actix-web = "4.2.1"
 shuttle-service = { version = '0.8.0', features = ["web-actix-web"] }
-

--- a/actix-web/hello-world/src/lib.rs
+++ b/actix-web/hello-world/src/lib.rs
@@ -1,14 +1,15 @@
-use actix_web::web::{resource, ServiceConfig};
+use actix_web::{get, web::ServiceConfig};
 use shuttle_service::ShuttleActixWeb;
 
+#[get("/hello")]
 async fn hello_world() -> &'static str {
     "Hello World!"
 }
 
 #[shuttle_service::main]
 async fn actix_web(
-) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Copy + Clone + 'static> {
+) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Clone + 'static> {
     Ok(move |cfg: &mut ServiceConfig| {
-        cfg.service(resource("/hello").to(hello_world));
+        cfg.service(hello_world);
     })
 }

--- a/actix-web/postgres/Cargo.toml
+++ b/actix-web/postgres/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "postgres"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+
+[dependencies]
+actix-web = "4.2.1"
+serde = "1.0.148"
+shuttle-service = { version = "0.8.0", features = ["web-actix-web"] }
+shuttle-shared-db = { version = "0.8.0", features = ["postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }

--- a/actix-web/postgres/schema.sql
+++ b/actix-web/postgres/schema.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS todos;
+
+CREATE TABLE todos (
+  id serial PRIMARY KEY,
+  note TEXT NOT NULL
+);

--- a/actix-web/postgres/src/lib.rs
+++ b/actix-web/postgres/src/lib.rs
@@ -1,0 +1,61 @@
+use actix_web::{
+    error, get, post,
+    web::{self, Json, ServiceConfig},
+    Result,
+};
+use serde::{Deserialize, Serialize};
+use shuttle_service::{error::CustomError, ShuttleActixWeb};
+use sqlx::{Executor, FromRow, PgPool};
+
+#[get("/todos/{id}")]
+async fn retrieve(id: web::Path<i32>, state: web::Data<AppState>) -> Result<Json<Todo>> {
+    let todo = sqlx::query_as("SELECT * FROM todos WHERE id = $1")
+        .bind(id.as_ref())
+        .fetch_one(&state.pool)
+        .await
+        .map_err(|e| error::ErrorBadRequest(e.to_string()))?;
+
+    Ok(Json(todo))
+}
+
+#[post("/todos")]
+async fn add(todo: web::Json<TodoNew>, state: web::Data<AppState>) -> Result<Json<Todo>> {
+    let todo = sqlx::query_as("INSERT INTO todos(note) VALUES ($1) RETURNING id, note")
+        .bind(&todo.note)
+        .fetch_one(&state.pool)
+        .await
+        .map_err(|e| error::ErrorBadRequest(e.to_string()))?;
+
+    Ok(Json(todo))
+}
+
+#[derive(Clone)]
+struct AppState {
+    pool: PgPool,
+}
+
+#[shuttle_service::main]
+async fn actix_web(
+    #[shuttle_shared_db::Postgres] pool: PgPool,
+) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Clone + 'static> {
+    pool.execute(include_str!("../schema.sql"))
+        .await
+        .map_err(CustomError::new)?;
+
+    let state = web::Data::new(AppState { pool });
+
+    Ok(move |cfg: &mut ServiceConfig| {
+        cfg.service(add).service(retrieve).app_data(state);
+    })
+}
+
+#[derive(Deserialize)]
+struct TodoNew {
+    pub note: String,
+}
+
+#[derive(Serialize, Deserialize, FromRow)]
+struct Todo {
+    pub id: i32,
+    pub note: String,
+}


### PR DESCRIPTION
The actix integration was not compatible with shared state (PgPool does not implement copy), so I removed the Copy bound from the examples and in service: https://github.com/shuttle-hq/shuttle/pull/523. I also added a postgres example for actix, and removed the unnecessary `actix-service` dep.