### PR TITLE
fix: path to serve assets from

### DIFF
--- a/axum/static-next-server/src/lib.rs
+++ b/axum/static-next-server/src/lib.rs
@@ -9,7 +9,7 @@ async fn axum(
     #[shuttle_static_folder::StaticFolder] static_folder: PathBuf,
 ) -> shuttle_service::ShuttleAxum {
     let router =
-        Router::new().merge(SpaRouter::new("/assets", static_folder).index_file("index.html"));
+        Router::new().merge(SpaRouter::new("/", static_folder).index_file("index.html"));
 
     let sync_wrapper = SyncWrapper::new(router);
 


### PR DESCRIPTION
The index.html generated by create-next-app assumes the assets are in `.`, so if we use `/assets` we will just see a page with text, no css, svgs etc.